### PR TITLE
More repo shortcuts. Close #1

### DIFF
--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleRepositoryHandlerImpl.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleRepositoryHandlerImpl.kt
@@ -114,6 +114,7 @@ class ChenilleRepositoryHandlerImpl(private val repositories: RepositoryHandler)
             repo.content {
                 it.includeGroupByRegex("me\\.shedaniel\\..*")
                 it.includeGroup("me.sargunvohra.mcmods")
+                it.includeGroup("dev.architectury")
             }
         }
     }

--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleRepositoryHandlerImpl.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleRepositoryHandlerImpl.kt
@@ -98,6 +98,16 @@ class ChenilleRepositoryHandlerImpl(private val repositories: RepositoryHandler)
         }
     }
 
+    override fun parchment() {
+        repositories.maven { repo ->
+            repo.name = "Parchment"
+            repo.setUrl("https://maven.parchmentmc.org")
+            repo.content {
+                it.includeGroup("org.parchmentmc")
+            }
+        }
+    }
+
     override fun shedaniel() {
         repositories.maven { repo ->
             repo.setUrl("https://maven.shedaniel.me/")
@@ -116,6 +126,20 @@ class ChenilleRepositoryHandlerImpl(private val repositories: RepositoryHandler)
                 it.includeGroup("com.terraformersmc")
                 it.includeGroup("dev.emi")
             }
+        }
+    }
+
+    override fun quiltMC() {
+        repositories.maven { repo ->
+            repo.name = "QuiltMC"
+            repo.setUrl("https://maven.quiltmc.org/repository/release")
+        }
+    }
+
+    override fun quiltMCSnapshot() {
+        repositories.maven { repo ->
+            repo.name = "QuiltMC Snapshot"
+            repo.setUrl("https://maven.quiltmc.org/repository/snapshot")
         }
     }
 }

--- a/src/main/kotlin/io/github/ladysnake/chenille/api/ChenilleRepositoryHandler.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/api/ChenilleRepositoryHandler.kt
@@ -26,6 +26,9 @@ interface ChenilleRepositoryHandler {
     fun ladysnake()
     fun lucko()
     fun modrinth()
+    fun parchment()
     fun shedaniel()
     fun terraformers()
+    fun quiltMC()
+    fun quiltMCSnapshot()
 }


### PR DESCRIPTION
The geckolib maven seems to be gone, and a very quick and small search didn't reveal much unfortunately.

I took a quick look at the other repositories on the org and noticed that quilt was used a few times, so figured having a shortcut could be useful.

I also noticed that in a few places that shedaniel's maven is specified anyway to include arch, so I added it as an include in general.