### PR TITLE
Add Fabric compatibility toggle

### DIFF
--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradleExtensionImpl.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradleExtensionImpl.kt
@@ -98,6 +98,7 @@ open class ChenilleGradleExtensionImpl(private val project: ChenilleProject) : C
                 project.tasks.named("remapJar", RemapJarTask::class.java)
             }.flatMap { it.archiveFile }
 
+            override var fabricCompatible = true
             override var quiltCompatible = true
             override var neoforgeCompatible = false
 

--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleProject.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleProject.kt
@@ -26,8 +26,6 @@ class ChenilleProject(private val project: Project): Project by project {
     val git: JGitWrapper? by lazy {
         try { JGitWrapper(Git.open(rootDir), project.findProperty("github_api_key")?.toString()) } catch (_: RepositoryNotFoundException) { null }
     }
-    val isFabricMod: Boolean
-        get() = pluginManager.hasPlugin("fabric-loom")
 
     val changelog = ChangelogText(this)
 

--- a/src/main/kotlin/io/github/ladysnake/chenille/api/PublishingConfiguration.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/api/PublishingConfiguration.kt
@@ -25,6 +25,11 @@ interface PublishingConfiguration {
     var mainArtifact: Any
 
     /**
+     * Whether this release is compatible with Fabric (default: true)
+     */
+    var fabricCompatible: Boolean
+
+    /**
      * Whether this release is compatible with Quilt (default: true)
      */
     var quiltCompatible: Boolean

--- a/src/main/kotlin/io/github/ladysnake/chenille/helpers/CurseGradleHelper.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/helpers/CurseGradleHelper.kt
@@ -55,7 +55,7 @@ internal object CurseGradleHelper {
                         "Please specify the compatible minecraft versions using the 'curseforge_versions' project property"
                     )
                     curseforgeVersions.toString().split("; ").forEach(proj::addGameVersion)
-                    if (project.isFabricMod) {
+                    if (cfg.fabricCompatible) {
                         proj.addGameVersion("Fabric")
                     }
                     if (cfg.quiltCompatible) {

--- a/src/main/kotlin/io/github/ladysnake/chenille/helpers/ModrinthHelper.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/helpers/ModrinthHelper.kt
@@ -56,7 +56,7 @@ internal object ModrinthHelper {
                 mcVersions.toString().split("; ").forEach {
                     ext.gameVersions.add(it)
                 }
-                if (project.isFabricMod) {
+                if (cfg.fabricCompatible) {
                     ext.loaders.add("fabric")
                 }
                 if (cfg.quiltCompatible) {


### PR DESCRIPTION
adds a toggle for Fabric compatibility, like the Quilt and NeoForge ones. Removes the automatic check for if a mod is for Fabric and instead defaults to true