### PR TITLE
Invert checks for using remap tasks

### DIFF
--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradleExtensionImpl.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradleExtensionImpl.kt
@@ -92,10 +92,10 @@ open class ChenilleGradleExtensionImpl(private val project: ChenilleProject) : C
             var modrinth = false
             var ladysnakeArtifactLifecycle: ArtifactLifecycle? = null
 
-            override var mainArtifact: Any = if (project.usesNewLoom()) {
-                project.tasks.named("jar", Jar::class.java)
-            } else {
+            override var mainArtifact: Any = if (project.usesRemapLoom()) {
                 project.tasks.named("remapJar", RemapJarTask::class.java)
+            } else {
+                project.tasks.named("jar", Jar::class.java)
             }.flatMap { it.archiveFile }
 
             override var quiltCompatible = true
@@ -182,7 +182,7 @@ open class ChenilleGradleExtensionImpl(private val project: ChenilleProject) : C
                 baseTestRuns = true
             }
             override fun withDependencyConfiguration() {
-                if (project.usesNewLoom()) {
+                if (!project.usesRemapLoom()) {
                     error("Dependency configuration helper is only available for projects with remapped configurations (before MC 26.1)")
                 }
                 dependencyConfiguration = true

--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradlePlugin.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleGradlePlugin.kt
@@ -36,10 +36,10 @@ class ChenilleGradlePlugin : Plugin<Project> {
 
         project.extensions.create(ChenilleGradleExtension::class.java, "chenille", ChenilleGradleExtensionImpl::class.java, project)
 
-        if (project.usesNewLoom()) {
-            setupConfigurations(project.configurations)
-        } else {
+        if (project.usesRemapLoom()) {
             setupRemappingConfigurations(project.configurations)
+        } else {
+            setupConfigurations(project.configurations)
         }
     }
 

--- a/src/main/kotlin/io/github/ladysnake/chenille/ChenilleProject.kt
+++ b/src/main/kotlin/io/github/ladysnake/chenille/ChenilleProject.kt
@@ -36,5 +36,5 @@ class ChenilleProject(private val project: Project): Project by project {
 
     fun isLadysnakeProject() = project.group.toString().takeIf { it.contains("ladysnake") || it.contains("onyxstudios") } != null
 
-    fun usesNewLoom() = pluginManager.hasPlugin("net.fabricmc.fabric-loom")
+    fun usesRemapLoom() = pluginManager.hasPlugin("net.fabricmc.fabric-loom-remap")
 }


### PR DESCRIPTION
Inverts the checks for using remap tasks vs regular tasks by checking specifically for `net.fabricmc.fabric-loom-remap` to avoid build failures in scenarios where `net.fabricmc.fabric-loom` may not be explicitly used, such as with `org.relativitymc.neo-loom`